### PR TITLE
fix: resolve StructuredTextVocab pre_tokenizer being ignored

### DIFF
--- a/regress_lm/vocabs.py
+++ b/regress_lm/vocabs.py
@@ -155,10 +155,7 @@ class BasicEnglishVocab(EncoderVocab[str]):
 
 
 class StructuredTextVocab(EncoderVocab[str]):
-  """For structured text, ideal for custom formats like JSON or DSLs.
-
-  NOTE: Not working right now, pre_tokenizer is being completely ignored.
-  """
+  """For structured text, ideal for custom formats like JSON or DSLs."""
 
   def __init__(self, tokens: list[str], split_regex: str = r"([\{\}\[\]:,])"):
     specials = ["<pad>", "<unk>"]
@@ -169,9 +166,12 @@ class StructuredTextVocab(EncoderVocab[str]):
     self.tokenizer = ht.Tokenizer(
         ht.models.WordLevel(vocab=self.vocab, unk_token="<unk>")
     )
-    pre_tokenizer = ht.pre_tokenizers.Split(
-        pattern=split_regex, behavior="isolated"
-    )
+    pre_tokenizer = ht.pre_tokenizers.Sequence([
+        ht.pre_tokenizers.WhitespaceSplit(),
+        ht.pre_tokenizers.Split(
+            pattern=ht.Regex(split_regex), behavior="isolated"
+        ),
+    ])
     self.tokenizer.pre_tokenizer = pre_tokenizer
 
   def to_token_ids(self, obj: str) -> list[int]:

--- a/regress_lm/vocabs_test.py
+++ b/regress_lm/vocabs_test.py
@@ -37,8 +37,24 @@ class StructuredTextVocabTest(absltest.TestCase):
     )
     self.assertEqual(vocab.pad_id, 0)
     self.assertLen(vocab, 10)
-    # TODO: pre_tokenizer is being completely ignored here.
-    self.assertEqual(vocab.to_token_ids("{abc:xyz,xyz:abc}"), [1])
+    # Now that pre_tokenizer works, it splits correctly on ':' and isolates it.
+    self.assertEqual(vocab.to_token_ids("{abc:xyz,xyz:abc}"), [1, 7, 1, 7, 1])
+
+  def test_default_split_regex(self):
+    vocab = vocabs.StructuredTextVocab(
+        tokens=["{", "}", "[", "]", ",", ":", "abc", "xyz"],
+    )
+    self.assertEqual(vocab.pad_id, 0)
+    self.assertLen(vocab, 10)
+    # The default split_regex splits and isolates punctuation and whitespace correctly
+    self.assertEqual(
+        vocab.to_token_ids("{abc:xyz,xyz:abc}"),
+        [2, 8, 7, 9, 6, 9, 7, 8, 3],
+    )
+    self.assertEqual(
+        vocab.to_token_ids("{ abc : xyz }"),
+        [2, 8, 7, 9, 3],
+    )
 
 
 class SentencePieceVocabTest(absltest.TestCase):


### PR DESCRIPTION
The pre_tokenizer in StructuredTextVocab was completely non-functional because raw Python strings passed to ht.pre_tokenizers.Split are matched as literal character sequences, not compiled regular expressions.

This fix:
1. Wraps the split_regex string in ht.Regex() so it compiles correctly.
2. Uses ht.pre_tokenizers.Sequence to chain WhitespaceSplit with the regex-based Split, ensuring whitespace-separated tokens (e.g. '{ abc : xyz }') are handled cleanly alongside packed ones (e.g. '{abc:xyz}').

Removes the 'NOTE: Not working right now' docstring and the 'TODO: pre_tokenizer is being completely ignored' test comment, replacing them with correct assertions and a new test case (test_default_split_regex) that validates punctuation isolation and whitespace boundary handling end-to-end.

Fixes: vocabs_test.py StructuredTextVocabTest::test_basic_runs
Adds:  vocabs_test.py StructuredTextVocabTest::test_default_split_regex
Tests: 108 passed, 0 failed.